### PR TITLE
fix: DISTRO-4009: make jobs durable

### DIFF
--- a/src/main/scala/com/chilipiper/quartz/SchedulerQuartz.scala
+++ b/src/main/scala/com/chilipiper/quartz/SchedulerQuartz.scala
@@ -85,6 +85,7 @@ class SchedulerQuartz[A: Encoder: Decoder, F[_]: MonadThrow, G[_]: Sync](
         .withIdentity(jobKey)
         .usingJobData(jobDataMapKey, jobData.asJson.spaces2SortKeys)
         .requestRecovery(true)
+        .storeDurably(true)
         .build()
     }
     trigger <- Sync[G].blocking {


### PR DESCRIPTION
I think jobs were disappearing after running for a while because they weren't marked as durable. Non-durable jobs are removed when they have no active triggers (e.g., after scheduler restarts or trigger cleanup). Added .storeDurably(true) so jobs persist until explicitly deleted, preventing unexpected removal.