### PR TITLE
chore: update .jira/config.yml with gw environment mappings

### DIFF
--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -3,14 +3,18 @@ deployments:
     development:
       - "sandbox"
       - "*-sandbox"
+      - "sandbox-gw"
     testing:
       - "testing"
       - "*-testing"
+      - "testing-gw"
     staging:
       - "staging"
       - "*-staging"
+      - "staging-gw"
     production:
       - "production"
+      - "production-gw"
       - "canary"
       - "*-production"
       - "*-canary"


### PR DESCRIPTION
chore: update .jira/config.yml with gw environment mappings

## Summary
- Adds `staging-gw`, `testing-gw`, `production-gw`, `sandbox-gw` to the Jira deployment environment mapping
- Aligns config with the canonical version from fire-outlook-addin
- Without these entries, deployments to `-gw` clusters are not visible in Jira tickets